### PR TITLE
Added LocalizeStringExtension.

### DIFF
--- a/src/AKSoftware.Localization.MultiLanguages.UWP/AKSoftware.Localization.MultiLanguages.UWP.csproj
+++ b/src/AKSoftware.Localization.MultiLanguages.UWP/AKSoftware.Localization.MultiLanguages.UWP.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Converters\LocalizationConverter.cs" />
     <Compile Include="Converters\MultiValueConverterBase.cs" />
     <Compile Include="Extensions\LanguageServiceExtension.cs" />
+    <Compile Include="Extensions\LocalizeStringExtension.cs" />
     <Compile Include="ExternalFileKeysProvider.cs" />
     <Compile Include="IServiceProviderHost.cs" />
     <Compile Include="LocalizationService.cs" />

--- a/src/AKSoftware.Localization.MultiLanguages.UWP/Extensions/LocalizeStringExtension.cs
+++ b/src/AKSoftware.Localization.MultiLanguages.UWP/Extensions/LocalizeStringExtension.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Windows.UI.Xaml.Markup;
+
+namespace AKSoftware.Localization.MultiLanguages.UWP.Extensions
+{
+    [MarkupExtensionReturnType(ReturnType = typeof(string))]
+    public class LocalizeStringExtension : MarkupExtension
+    {
+        public string Key { get; set; }
+
+        public bool Capitalize { get; set; }
+
+        protected override object ProvideValue()
+        {
+            var language = ((IServiceProviderHost)Windows.UI.Xaml.Application.Current).ServiceProvider.GetService<ILanguageContainerService>();
+            var value = language?[Key];
+
+            return Capitalize ? value?.ToUpperInvariant() : value;
+
+        }
+    }
+}

--- a/src/AKSoftware.Localization.MultiLanguages/ServiceExtensions.cs
+++ b/src/AKSoftware.Localization.MultiLanguages/ServiceExtensions.cs
@@ -7,11 +7,11 @@ namespace AKSoftware.Localization.MultiLanguages
 {
     public static class ServiceExtensions
     {
-
         /// <summary>
         /// Register a singleton instance of LanguageContainer class initialized with a specific culture
         /// </summary>
         /// <param name="services">Dependency Services provider</param>
+        /// <param name="assembly"></param>
         /// <param name="culture">Initial culture</param>
         /// <returns></returns>
         public static IServiceCollection AddLanguageContainer(this IServiceCollection services, Assembly assembly, CultureInfo culture, string folderName = "Resources")
@@ -46,6 +46,7 @@ namespace AKSoftware.Localization.MultiLanguages
         /// </summary>
         /// <param name="services">Dependency Services provider</param>
         /// <param name="assembly">Assembly that contains the Resource folder which has the language files</param>
+        /// <param name="folderName"></param>
         /// <returns></returns>
         public static IServiceCollection AddLanguageContainer<TKeysProvider>(this IServiceCollection services, Assembly assembly, string folderName = "Resources")
         where TKeysProvider : KeysProvider

--- a/src/UwpAkLocalization/App.xaml.cs
+++ b/src/UwpAkLocalization/App.xaml.cs
@@ -125,9 +125,9 @@ namespace UwpAkLocalization
             //     C:\Users\<your user>\AppData\Local\Packages\e8428150-51ff-4bd2-8842-7dbd0047d3da_3xecenf62363c\LocalState.  
             //  
             //*************************************************************************************************
-            //serviceCollection_.AddLanguageContainer<EmbeddedResourceKeysProvider>(Assembly.GetExecutingAssembly(),  "Resources");
+            serviceCollection_.AddLanguageContainer<EmbeddedResourceKeysProvider>(Assembly.GetExecutingAssembly(),  "Resources");
             //serviceCollection_.AddLanguageContainer<ExternalFileKeysProvider>(Assembly.GetExecutingAssembly(), LocalizationFolderType.InstallationFolder, "Resources");
-            serviceCollection_.AddLanguageContainer<ExternalFileKeysProvider>(Assembly.GetExecutingAssembly(), LocalizationFolderType.LocalFolder, "Localization");
+            //serviceCollection_.AddLanguageContainer<ExternalFileKeysProvider>(Assembly.GetExecutingAssembly(), LocalizationFolderType.LocalFolder, "Localization");
             ServiceProvider = serviceCollection_.BuildServiceProvider();
         }
     }

--- a/src/UwpAkLocalization/MainPage.xaml
+++ b/src/UwpAkLocalization/MainPage.xaml
@@ -8,6 +8,7 @@
     xmlns:converters="using:AKSoftware.Localization.MultiLanguages.UWP.Converters"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:behaviors="using:AKSoftware.Localization.MultiLanguages.UWP.Behaviors"
+    xmlns:markup="using:AKSoftware.Localization.MultiLanguages.UWP.Extensions"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     DataContext="{Binding Mode=OneWay, RelativeSource={RelativeSource Self}}">
@@ -27,8 +28,8 @@
     </Style>
     </Page.Resources>
     <StackPanel Orientation="Vertical" Style="{StaticResource OuterStackPanelStyle}">
-       
-        <TextBlock Text="{Binding Localization[HomePage:HelloWorld] }" Style="{StaticResource LargeHeaderLabelStyle}"></TextBlock>
+
+        <TextBlock Text="{markup:LocalizeString Key=HomePage:HelloWorld, Capitalize=True }" Style="{StaticResource LargeHeaderLabelStyle}"></TextBlock>
         <TextBlock Style="{StaticResource LabelStyle}">
             <interactivity:Interaction.Behaviors>
                 <behaviors:MultiBindingBehavior PropertyName="Text" Converter="{StaticResource LocalizationConverter}" >

--- a/src/UwpAkLocalization/MainPage.xaml.cs
+++ b/src/UwpAkLocalization/MainPage.xaml.cs
@@ -18,7 +18,7 @@ namespace UwpAkLocalization
         {
             this.InitializeComponent();
             SuppressPageAnimation();
-            Localization = (Application.Current as IServiceProviderHost).ServiceProvider.GetService<ILanguageContainerService>();
+            Localization = ((IServiceProviderHost)Application.Current).ServiceProvider.GetService<ILanguageContainerService>();
         }
 
         private void SuppressPageAnimation()


### PR DESCRIPTION
This PR adds a markup extension called LocalizeStringExtension.  It also removes a few compiler warnings.  Additionally the UWP sample app has been updated to demonstrate using the extension.