### PR TITLE
Fix LanguageContainer Constructor order + Retrieving LanguageFileName exception on empty culture (Ubuntu)

### DIFF
--- a/src/AKSoftware.Localization.MultiLanguages/KeysProvider.cs
+++ b/src/AKSoftware.Localization.MultiLanguages/KeysProvider.cs
@@ -29,7 +29,9 @@ namespace AKSoftware.Localization.MultiLanguages
             var languageFileNames = GetLanguageFileNames();
 
             // Get the keys from the file that has the current culture 
-            var keys = InternalGetKeys(languageFileNames.SingleOrDefault(n => n.Contains($"{culture.Name}.yml") || n.Contains($"{culture.Name}.yaml")));
+            var keys = !string.IsNullOrWhiteSpace(culture.Name)
+                ? InternalGetKeys(languageFileNames.FirstOrDefault(n => n.Contains($"{culture.Name}.yml") || n.Contains($"{culture.Name}.yaml")))
+                : default;
 
             // Get the keys from a file that has the same language 
             if (keys == null)

--- a/src/AKSoftware.Localization.MultiLanguages/LanguageContainer.cs
+++ b/src/AKSoftware.Localization.MultiLanguages/LanguageContainer.cs
@@ -14,20 +14,19 @@ namespace AKSoftware.Localization.MultiLanguages
         /// Create instance of the container initialized with the specific culture
         /// </summary>
         /// <param name="culture"></param>
-        /// <param name="keyProvider"></param>
-        public LanguageContainer(CultureInfo culture, IKeysProvider keyProvider) : this(keyProvider)
+        /// <param name="keysProvider"></param>
+        public LanguageContainer(CultureInfo culture, IKeysProvider keysProvider)
         {
+            _keysProvider = keysProvider;
+            _extensions = new List<IExtension>();
             SetLanguage(culture, true);
         }
 
         /// <summary>
         /// Create instance of the container initialized with the default culture
         /// </summary>
-        public LanguageContainer(IKeysProvider keysProvider)
+        public LanguageContainer(IKeysProvider keysProvider) : this(CultureInfo.CurrentCulture, keysProvider)
         {
-            _keysProvider = keysProvider;
-            _extensions = new List<IExtension>();
-            SetLanguage(CultureInfo.CurrentCulture, true);
         }
 
         /// <summary>


### PR DESCRIPTION
Some fixes for minor issues I ran into while attempting to run my Blazor web project using the Multilanguage library in Ubuntu (WSL/Docker):

- Fix the order of the LanguageContainer constructors (the base Constructor gets called before the derived one does).
- On Ubuntu (WSL/Docker) the CultureInfo.CurrentCulture seems to be empty by default, resulting in an exception in the GetKeys method of the GetKeysProvider. The SingleOrDefault on line 32 threw an exception, because the SingleOrDefault expression resulted in retrieving all the yml language files.