### PR TITLE
Resolve the behavior when a child key is not found

### DIFF
--- a/src/AKSoftware.Localization.MultiLanguages.Tests/LanguagesContainerWithEmbeddedKeysProviderTests.cs
+++ b/src/AKSoftware.Localization.MultiLanguages.Tests/LanguagesContainerWithEmbeddedKeysProviderTests.cs
@@ -125,5 +125,11 @@ namespace AKSoftware.Localization.MultiLanguages.Tests
             Assert.Equal("Feliz Navidad!", value);
         }
 
+        [Fact]
+		public void GetNestedValue_When_NestedKey_NotFound_Should_Return_NestedKeyOnly()
+        {
+			var value = _service["HomePage:NotFound"];
+			Assert.Equal("NotFound", value);
+		}
     }
 }

--- a/src/AKSoftware.Localization.MultiLanguages/AKSoftware.Localization.MultiLanguages.csproj
+++ b/src/AKSoftware.Localization.MultiLanguages/AKSoftware.Localization.MultiLanguages.csproj
@@ -14,10 +14,10 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageIcon>AkMultiLanguages.png</PackageIcon>
-    <AssemblyVersion>5.9.1</AssemblyVersion>
-    <FileVersion>5.9.1.0</FileVersion>
+    <AssemblyVersion>5.9.11</AssemblyVersion>
+    <FileVersion>5.9.11.0</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>5.9.1</Version>
+    <Version>5.9.11</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/src/AKSoftware.Localization.MultiLanguages/Keys.cs
+++ b/src/AKSoftware.Localization.MultiLanguages/Keys.cs
@@ -7,175 +7,173 @@ using YamlDotNet.Serialization;
 
 namespace AKSoftware.Localization.MultiLanguages
 {
-    public class Keys
-    {
-        IReadOnlyDictionary<object, object> keyValues = null;
-        private const string PLACEHOLDER_PATTERN = @"{([^}]*)}";
+	public class Keys
+	{
+		IReadOnlyDictionary<object, object> keyValues = null;
+		private const string PLACEHOLDER_PATTERN = @"{([^}]*)}";
 
-        /// <summary>
-        /// Initialize the language object for a specific culture
-        /// </summary>
-        /// <param name="languageContent">String content that has the YAML language</param>
-        public Keys(string languageContent)
-        {
-            initialize(languageContent);
-        }
+		/// <summary>
+		/// Initialize the language object for a specific culture
+		/// </summary>
+		/// <param name="languageContent">String content that has the YAML language</param>
+		public Keys(string languageContent)
+		{
+			initialize(languageContent);
+		}
 
-        /// <summary>
-        /// Initialize the language file from the selected culture
-        /// </summary>
-        /// <param name="languageContent">String content that has the YAML language</param>
-        public void initialize(string languageContent)
-        {
-            keyValues = new Deserializer().Deserialize<Dictionary<object, object>>(languageContent);
-        }
+		/// <summary>
+		/// Initialize the language file from the selected culture
+		/// </summary>
+		/// <param name="languageContent">String content that has the YAML language</param>
+		public void initialize(string languageContent)
+		{
+			keyValues = new Deserializer().Deserialize<Dictionary<object, object>>(languageContent);
+		}
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        public string this[string key]
-        {
-            get
-            {
-                var value = GetValue(key);
-                
-                //var placeholders = Regex.Matches(value, PLACEHOLDER_PATTERN);
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="key"></param>
+		/// <returns></returns>
+		public string this[string key]
+		{
+			get
+			{
+				var value = GetValue(key);
 
-                //if (placeholders.Count > 0)
-                //    throw new ArgumentException("Value contains placeholders, use the overload Keys indexer to pass values, to learn more check the Interpolation documentation: https://github.com/aksoftware98/multilanguages");
+				//var placeholders = Regex.Matches(value, PLACEHOLDER_PATTERN);
 
-                return value; 
-            }
-        }
+				//if (placeholders.Count > 0)
+				//    throw new ArgumentException("Value contains placeholders, use the overload Keys indexer to pass values, to learn more check the Interpolation documentation: https://github.com/aksoftware98/multilanguages");
 
-        public class StringComparerIgnoreCase : IEqualityComparer<string>
-        {
-            public bool Equals(string x, string y)
-            {
-                if (x != null && y != null)
-                {
-                    return x.ToLowerInvariant() == y.ToLowerInvariant();
-                }
-                return false;
-            }
+				return value;
+			}
+		}
 
-            public int GetHashCode(string obj)
-            {
-                return obj.ToLowerInvariant().GetHashCode();
-            }
-        }
+		public class StringComparerIgnoreCase : IEqualityComparer<string>
+		{
+			public bool Equals(string x, string y)
+			{
+				if (x != null && y != null)
+				{
+					return x.ToLowerInvariant() == y.ToLowerInvariant();
+				}
+				return false;
+			}
 
-        public string this[string key, IDictionary<string, object> values, bool setEmptyForNull = false]
-        {
-            get
-            {
-                if (values == null) 
-                { 
-                    throw new ArgumentNullException(nameof(values));
-                }
-                var caseInvariantValues = new Dictionary<string, object>(values, new StringComparerIgnoreCase());
-                var localizedString = GetValue(key);
-                var matches = Regex.Matches(localizedString, PLACEHOLDER_PATTERN);
-                foreach (Match item in matches)
-                {
-                    var replacementKey = item.Value.Replace("{", "").Replace("}", "");
+			public int GetHashCode(string obj)
+			{
+				return obj.ToLowerInvariant().GetHashCode();
+			}
+		}
 
-                    var replacementObject = caseInvariantValues[replacementKey];
-                    if (replacementObject == null && !setEmptyForNull) 
-                    { 
-                        throw new ArgumentNullException(nameof(item.Value));
-                    }
-                    var replacementValue = replacementObject == null ? string.Empty : replacementObject.ToString();
-                    localizedString = localizedString.Replace($"{item.Value}", replacementValue);
-                }
-                return localizedString;
-            }
-        }
+		public string this[string key, IDictionary<string, object> values, bool setEmptyForNull = false]
+		{
+			get
+			{
+				if (values == null)
+				{
+					throw new ArgumentNullException(nameof(values));
+				}
+				var caseInvariantValues = new Dictionary<string, object>(values, new StringComparerIgnoreCase());
+				var localizedString = GetValue(key);
+				var matches = Regex.Matches(localizedString, PLACEHOLDER_PATTERN);
+				foreach (Match item in matches)
+				{
+					var replacementKey = item.Value.Replace("{", "").Replace("}", "");
 
-
-        public string this[string key, object keyValues, bool setEmptyForNull = false]
-        {
-            get
-            {
-                if (keyValues == null)
-                    throw new ArgumentNullException(nameof(keyValues));
-
-                var properties = keyValues.GetType().GetProperties();
-
-                var keyValue = GetValue(key);
-                string processedValue = keyValue;
-
-                var matches = Regex.Matches(keyValue, PLACEHOLDER_PATTERN);
-                foreach (Match item in matches)
-                {
-                    string internalValue = item.Value.Replace("{", "").Replace("}", "");
-                    // Get the corresponding property 
-                    var matchedProperties = properties.Where(p => p.Name.Equals(internalValue, StringComparison.InvariantCultureIgnoreCase)).ToArray();
-                    if (matchedProperties.Length > 1)
-                        throw new AmbiguousMatchException($"Multiple properties have the same name to be replaced '{item.Value}'");
-
-                    var propertyValue = matchedProperties.First().GetValue(keyValues);
-                    string propertyValueAsString = string.Empty;
-                    if (propertyValue == null && !setEmptyForNull)
-                            throw new ArgumentNullException(nameof(item.Value));
-                    else
-                        propertyValueAsString = propertyValue?.ToString(); 
-
-                    processedValue = processedValue.Replace($"{item.Value}", propertyValueAsString);
-                }
-
-                return processedValue;
-            }
-        }
+					var replacementObject = caseInvariantValues[replacementKey];
+					if (replacementObject == null && !setEmptyForNull)
+					{
+						throw new ArgumentNullException(nameof(item.Value));
+					}
+					var replacementValue = replacementObject == null ? string.Empty : replacementObject.ToString();
+					localizedString = localizedString.Replace($"{item.Value}", replacementValue);
+				}
+				return localizedString;
+			}
+		}
 
 
-        private string GetValue(string key)
-        {
-            try
-            {
-                if (key.Contains(":"))
-                {
-                    string[] nestedKey = key.Split(':');
-                    var nestedValue = keyValues[nestedKey[0]] as Dictionary<object, object>;
+		public string this[string key, object keyValues, bool setEmptyForNull = false]
+		{
+			get
+			{
+				if (keyValues == null)
+					throw new ArgumentNullException(nameof(keyValues));
+
+				var properties = keyValues.GetType().GetProperties();
+
+				var keyValue = GetValue(key);
+				string processedValue = keyValue;
+
+				var matches = Regex.Matches(keyValue, PLACEHOLDER_PATTERN);
+				foreach (Match item in matches)
+				{
+					string internalValue = item.Value.Replace("{", "").Replace("}", "");
+					// Get the corresponding property 
+					var matchedProperties = properties.Where(p => p.Name.Equals(internalValue, StringComparison.InvariantCultureIgnoreCase)).ToArray();
+					if (matchedProperties.Length > 1)
+						throw new AmbiguousMatchException($"Multiple properties have the same name to be replaced '{item.Value}'");
+
+					var propertyValue = matchedProperties.First().GetValue(keyValues);
+					string propertyValueAsString = string.Empty;
+					if (propertyValue == null && !setEmptyForNull)
+						throw new ArgumentNullException(nameof(item.Value));
+					else
+						propertyValueAsString = propertyValue?.ToString();
+
+					processedValue = processedValue.Replace($"{item.Value}", propertyValueAsString);
+				}
+
+				return processedValue;
+			}
+		}
+
+
+		private string GetValue(string key)
+		{
+			if (key.Contains(":"))
+			{
+				string[] nestedKey = key.Split(':');
+				var nestedValue = keyValues[nestedKey[0]] as Dictionary<object, object>;
+				if (nestedValue == null)
+					return key;
+
+				string value = string.Empty;
+				for (int i = 1; i < nestedKey.Length; i++)
+				{
+					if (i == nestedKey.Length - 1)
+					{
+						var isValueExisting = nestedValue.TryGetValue(nestedKey[i], out object valueObject);
+						if (isValueExisting)
+						{
+							if (valueObject is string)
+								return (string)valueObject;
+							else
+								return nestedKey[i];
+						}
+						else
+							return nestedKey[i];
+					}
+
+					nestedValue = nestedValue[nestedKey[i]] as Dictionary<object, object>;
 					if (nestedValue == null)
-						return key; 
-					
-					string value = string.Empty;
-                    for (int i = 1; i < nestedKey.Length; i++)
-                    {
-                        if (i == nestedKey.Length - 1)
-                        {
-                            var result = nestedValue[nestedKey[i]];
-                            if (result is string)
-                                return (string)result;
-                            else
-                                return key;
-                        }
+						return nestedKey[i];
+				}
 
-                        nestedValue = nestedValue[nestedKey[i]] as Dictionary<object, object>;
-                        if (nestedValue == null)
-                            return key;
-                    }
+				return value;
+			}
+			else
+			{
+				var result = keyValues[key];
+				if (result == null)
+					return key;
 
-                    return value;
-                }
-                else
-                {
-                    var result = keyValues[key];
-                    if (result == null)
-                        return key;
+				return (string)result;
 
-                    return (string)result;
-
-                }
-            }
-            catch
-            {
-                return key;
-            }
-        }
-    }
+			}
+		}
+	}
 }
 


### PR DESCRIPTION
Before version 5.9.1 when trying to access a not found nested key, it returns the name of the nested key for example accessing the following not found key ***HomePage:NotFound*** would return ***NotFound***

In version 5.9.1, ***HomePage:NotFound*** is returning ***HomePage:NotFound***

This PR address this issue.

